### PR TITLE
Adding 015_binary_search_Scala.scala 047_quicksort_Erlang.erl 063_shortest_path_Go.go

### DIFF
--- a/dev_src/015_binary_search_Scala.scala
+++ b/dev_src/015_binary_search_Scala.scala
@@ -1,0 +1,124 @@
+// BinarySearch.scala
+// Scala CLI: Binary search (first occurrence) on a sorted ascending array of integers.
+//
+// Build/Run (Scala 2.13 or 3.x):
+//   scalac BinarySearch.scala && scala BinarySearch <target> [path/to/file]
+//   # or via STDIN (one number per line):
+//   printf "1\n3\n4\n7\n9\n11\n15\n" | scala BinarySearch 11
+//
+// Behavior
+//   • O(log N) search; returns the FIRST index if duplicates exist (stable-left).
+//   • On hit : prints  FOUND <target> at index <i> (1-based)
+//   • On miss: prints  NOT FOUND <target>. Insertion index <i> (1-based), between <left> and <right>
+//   • Validates non-decreasing order; exits with error if violated.
+
+import scala.io.Source
+import scala.util.Try
+
+object BinarySearch {
+  def main(args: Array[String]): Unit = {
+    if (args.length < 1) {
+      Console.err.println("ERROR: missing <target>")
+      usage()
+      sys.exit(2)
+    }
+
+    val target: Long = Try(args(0).toLong).getOrElse {
+      Console.err.println(s"ERROR: target must be integer, got '${args(0)}'")
+      usage(); sys.exit(2); 0L
+    }
+
+    val numbers: Vector[Long] =
+      try {
+        if (args.length >= 2) readNumbers(Source.fromFile(args(1)))
+        else readNumbers(Source.stdin)
+      } catch {
+        case e: Exception =>
+          Console.err.println(s"ERROR: failed to read input: ${e.getMessage}")
+          sys.exit(1); Vector.empty
+      }
+
+    if (numbers.isEmpty) {
+      Console.err.println("ERROR: no numeric input provided.")
+      sys.exit(1)
+    }
+
+    ensureAscending(numbers) match {
+      case Some(err) =>
+        Console.err.println(err)
+        sys.exit(1)
+      case None => // ok
+    }
+
+    val (idx1, found, ins1) = binarySearchFirst(numbers, target)
+
+    if (found) {
+      println(s"FOUND $target at index $idx1 (1-based)")
+    } else {
+      val left  = if (ins1 >= 2) numbers(ins1 - 2).toString else "-inf"
+      val right = if ((ins1 - 1) < numbers.length) numbers(ins1 - 1).toString else "+inf"
+      println(s"NOT FOUND $target. Insertion index $ins1 (1-based), between $left and $right")
+    }
+  }
+
+  /** Read integers (one per line). Non-numeric lines are skipped with a warning. */
+  def readNumbers(src: Source): Vector[Long] = {
+    try {
+      val buf = Vector.newBuilder[Long]
+      var lineNo = 0
+      for (line <- src.getLines()) {
+        lineNo += 1
+        val s = line.trim
+        if (s.nonEmpty) {
+          Try(s.toLong).toOption match {
+            case Some(v) => buf += v
+            case None    => Console.err.println(s"WARN: skipping non-integer line $lineNo: $s")
+          }
+        }
+      }
+      buf.result()
+    } finally src.close()
+  }
+
+  /** Ensure non-decreasing order; return Some(errorMsg) if violated. */
+  def ensureAscending(a: Vector[Long]): Option[String] = {
+    var i = 1
+    while (i < a.length) {
+      if (a(i) < a(i - 1))
+        return Some(s"ERROR: input not in ascending order at position ${i + 1}: ${a(i)} < ${a(i - 1)}")
+      i += 1
+    }
+    None
+  }
+
+  /** Binary search for first occurrence (stable-left).
+    * Returns (index_1based, found, insertion_index_1based).
+    */
+  def binarySearchFirst(a: Vector[Long], target: Long): (Int, Boolean, Int) = {
+    var lo = 0
+    var hi = a.length - 1
+    var found = -1
+
+    while (lo <= hi) {
+      val mid = lo + (hi - lo) / 2
+      val v = a(mid)
+      if (v == target) {
+        found = mid
+        hi = mid - 1 // keep searching left
+      } else if (v < target) {
+        lo = mid + 1
+      } else {
+        hi = mid - 1
+      }
+    }
+
+    if (found >= 0) (found + 1, true, lo + 1)
+    else (0, false, lo + 1)
+  }
+
+  def usage(): Unit = {
+    Console.err.println("Usage:")
+    Console.err.println("  scala BinarySearch <target> [path/to/file]")
+    Console.err.println("""  printf "1\n3\n4\n7\n9\n11\n15\n" | scala BinarySearch 11""")
+  }
+}

--- a/dev_src/047_quicksort_Erlang.erl
+++ b/dev_src/047_quicksort_Erlang.erl
@@ -1,0 +1,167 @@
+%% in_place_quicksort.erl — Erlang — In-place quicksort on an integer array.
+%%
+%% What “in-place” means in Erlang:
+%%   Erlang data are immutable, but we can simulate in-place updates efficiently
+%%   using an ETS table (index -> value). We partition and swap by mutating ETS.
+%%
+%% Build:
+%%   erlc in_place_quicksort.erl
+%%
+%% Run (from shell):
+%%   # from file
+%%   erl -noshell -s in_place_quicksort main "input.txt" -s init stop
+%%   # from STDIN (end with Ctrl-D/Ctrl-Z)
+%%   erl -noshell -s in_place_quicksort main -s init stop
+%%
+%% Input format:
+%%   One integer per line (blank lines ignored). Whitespace is ok.
+
+-module(in_place_quicksort).
+-export([main/0, main/1]).
+
+-define(TABLE_OPTS, [set, protected, {read_concurrency, true}, {write_concurrency, true}]).
+
+%% ---------- Entry points ----------
+
+main() ->
+    main([]).
+
+main(Args) ->
+    Ints =
+        case Args of
+            [] -> read_all_ints_stdin();
+            [Filename] -> read_all_ints_file(Filename);
+            _ -> usage_and_halt()
+        end,
+    N = length(Ints),
+    T = ets:new(qarr, ?TABLE_OPTS),
+    load_ets(T, Ints),              % 1..N
+    quicksort_ets(T, 1, N),
+    print_ets(T, N),
+    ets:delete(T),
+    ok.
+
+usage_and_halt() ->
+    io:format("Usage: erl -noshell -s in_place_quicksort main \"input.txt\" -s init stop~n"
+              "   or: erl -noshell -s in_place_quicksort main -s init stop (read from STDIN)~n"),
+    halt(1).
+
+%% ---------- I/O helpers ----------
+
+read_all_ints_file(Filename) ->
+    {ok, Bin} = file:read_file(Filename),
+    lines_to_ints(string:split(binary_to_list(Bin), "\n", all)).
+
+read_all_ints_stdin() ->
+    read_stdin_lines([]).
+
+read_stdin_lines(Acc) ->
+    case io:get_line("") of
+        eof -> lists:reverse(Acc) |> lines_to_ints();
+        Line -> read_stdin_lines([Line | Acc])
+    end.
+
+lines_to_ints(Lines) ->
+    Clean = [string:trim(L) || L <- Lines],
+    IntStrs = [L || L <- Clean, L =/= ""],
+    [ list_to_integer(S) || S <- IntStrs ].
+
+print_ets(T, N) ->
+    lists:foreach(
+      fun(I) ->
+          {_, V} = ets:lookup_element(T, I, 2) orelse erlang:error({missing_index, I}),
+          io:format("~p~n", [V])
+      end,
+      lists:seq(1, N)).
+
+%% ---------- ETS array ops ----------
+
+load_ets(T, Ints) ->
+    _ = lists:foldl(
+          fun(V, {Idx, Acc}) ->
+                  ets:insert(T, {Idx, V}),
+                  {Idx+1, Acc}
+          end, {1, ok}, Ints),
+    ok.
+
+get(T, I) ->
+    case ets:lookup(T, I) of
+        [{_, V}] -> V;
+        [] -> erlang:error({bad_index, I})
+    end.
+
+set(T, I, V) ->
+    ets:insert(T, {I, V}).
+
+swap(T, I, J) when I =:= J -> ok;
+swap(T, I, J) ->
+    Vi = get(T, I),
+    Vj = get(T, J),
+    set(T, I, Vj),
+    set(T, J, Vi).
+
+median3(A, B, C) ->
+    case true of
+        _ when (A =< B andalso B =< C) orelse (C =< B andalso B =< A) -> B;
+        _ when (B =< A andalso A =< C) orelse (C =< A andalso A =< B) -> A;
+        _ -> C
+    end.
+
+%% Hoare partition on ETS-backed array [Lo..Hi], returns J boundary index.
+hoare_partition(T, Lo, Hi) ->
+    Mid   = Lo + (Hi - Lo) div 2,
+    Pivot = median3(get(T, Lo), get(T, Mid), get(T, Hi)),
+    I0 = Lo - 1,
+    J0 = Hi + 1,
+    hoare_step(T, Pivot, I0, J0).
+
+hoare_step(T, Pivot, I, J) ->
+    I1 = next_i(T, Pivot, I+1),
+    J1 = next_j(T, Pivot, J-1),
+    if
+        I1 >= J1 -> J1;
+        true ->
+            swap(T, I1, J1),
+            hoare_step(T, Pivot, I1, J1)
+    end.
+
+next_i(T, Pivot, I) ->
+    case get(T, I) < Pivot of
+        true  -> next_i(T, Pivot, I+1);
+        false -> I
+    end.
+
+next_j(T, Pivot, J) ->
+    case get(T, J) > Pivot of
+        true  -> next_j(T, Pivot, J-1);
+        false -> J
+    end.
+
+%% Iterative quicksort using explicit stack of {Lo,Hi}, sorting ETS “in place”.
+quicksort_ets(_T, _Lo, N) when N =< 1 -> ok;
+quicksort_ets(T, Lo, Hi) ->
+    quicksort_loop(T, [{Lo, Hi}]).
+
+quicksort_loop(_T, []) -> ok;
+quicksort_loop(T, [{Lo, Hi} | Rest]) when Lo < Hi ->
+    P = hoare_partition(T, Lo, Hi),
+    LLo = Lo,  LHi = P,
+    RLo = P+1, RHi = Hi,
+    LLen = LHi - LLo + 1,
+    RLen = RHi - RLo + 1,
+    %% push smaller segment first to keep stack shallow
+    NewStack =
+        case LLen =< RLen of
+            true  ->
+                S1 = (LLen > 1) andalso [{LLo, LHi}] orelse [],
+                S2 = (RLen > 1) andalso [{RLo, RHi}] orelse [],
+                S1 ++ S2 ++ Rest;
+            false ->
+                S1 = (RLen > 1) andalso [{RLo, RHi}] orelse [],
+                S2 = (LLen > 1) andalso [{LLo, LHi}] orelse [],
+                S1 ++ S2 ++ Rest
+        end,
+    quicksort_loop(T, NewStack);
+quicksort_loop(T, [_ | Rest]) ->
+    quicksort_loop(T, Rest).
+

--- a/dev_src/063_shortest_path_Go.go
+++ b/dev_src/063_shortest_path_Go.go
@@ -1,0 +1,190 @@
+// bfs_unweighted.go
+// Breadth-first search (BFS) shortest path on an unweighted, undirected graph.
+//
+// INPUT FORMAT (tab- or space-separated; one edge per line; queries start with '#'):
+//   A   B   F
+//   B   A   C
+//   C   B   D
+//   D   C   E
+//   E   D   F
+//   F   A   E
+//   #   A   E
+//
+// USAGE
+//   go run bfs_unweighted.go graph.tsv
+//   # or pipe:
+//   cat graph.tsv | go run bfs_unweighted.go
+//
+// OUTPUT
+//   One line per query, either "SRC -> ... -> DST" or an explanatory message.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type pair struct{ src, dst string }
+
+func main() {
+	var in *os.File
+	if len(os.Args) >= 2 {
+		f, err := os.Open(os.Args[1])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to open %s: %v\n", os.Args[1], err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		in = f
+	} else {
+		in = os.Stdin
+	}
+
+	adj, queries := parseInput(in)
+	if len(queries) == 0 {
+		fmt.Println(`No queries found (expect lines like: "#  SRC  DST"). Nothing to do.`)
+		return
+	}
+
+	for _, q := range queries {
+		if q.src == q.dst {
+			fmt.Println(q.src)
+			continue
+		}
+		if _, ok := adj[q.src]; !ok {
+			fmt.Printf("No path found from %s to %s (source not in graph)\n", q.src, q.dst)
+			continue
+		}
+		if _, ok := adj[q.dst]; !ok {
+			fmt.Printf("No path found from %s to %s (destination not in graph)\n", q.src, q.dst)
+			continue
+		}
+		path := bfsPath(adj, q.src, q.dst)
+		if len(path) == 0 {
+			fmt.Printf("No path found from %s to %s\n", q.src, q.dst)
+		} else {
+			fmt.Println(strings.Join(path, " -> "))
+		}
+	}
+}
+
+//--------------------------- Parsing & Utilities ---------------------------//
+
+// parseInput reads whitespace-separated tokens per line. Lines that start with
+// '#' are queries "# SRC DST". Other lines encode edges "U V1 [V2 ...]"
+// and are treated as undirected edges U—V1, U—V2, ...
+func parseInput(in *os.File) (map[string][]string, []pair) {
+	adj := make(map[string][]string)
+	var queries []pair
+
+	sc := bufio.NewScanner(in)
+	// Increase buffer for very long lines (e.g., many neighbors)
+	const maxCapacity = 4 << 20 // 4 MiB
+	buf := make([]byte, 0, 64<<10)
+	sc.Buffer(buf, maxCapacity)
+
+	for lineNum := 1; sc.Scan(); lineNum++ {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		// Normalize internal whitespace
+		toks := strings.Fields(line)
+		if len(toks) == 0 {
+			continue
+		}
+		if strings.HasPrefix(toks[0], "#") {
+			if len(toks) < 3 {
+				// Graceful skip of malformed query
+				continue
+			}
+			queries = append(queries, pair{src: toks[1], dst: toks[2]})
+			continue
+		}
+		if len(toks) < 2 {
+			// Malformed edge line; skip
+			continue
+		}
+		u := toks[0]
+		for _, v := range toks[1:] {
+			addUndirectedEdge(adj, u, v)
+		}
+	}
+	// Note: ignoring sc.Err() to keep output clean for pipelines; in production, handle it.
+
+	return adj, queries
+}
+
+func addUndirectedEdge(adj map[string][]string, u, v string) {
+	addDirectedUnique(adj, u, v)
+	addDirectedUnique(adj, v, u)
+}
+
+func addDirectedUnique(adj map[string][]string, u, v string) {
+	nb := adj[u]
+	// Deduplicate neighbor entries without allocating a set
+	for _, x := range nb {
+		if x == v {
+			return
+		}
+	}
+	adj[u] = append(nb, v)
+}
+
+//--------------------------- BFS Shortest Path -----------------------------//
+
+// bfsPath returns the shortest path from src to dst as a slice of node labels,
+// or an empty slice if no path exists. Graph is unweighted & undirected.
+func bfsPath(adj map[string][]string, src, dst string) []string {
+	if src == dst {
+		return []string{src}
+	}
+
+	visited := make(map[string]bool, len(adj))
+	parent := make(map[string]string, len(adj))
+
+	// Simple queue using a slice with head index to avoid O(n) pops.
+	q := make([]string, 0, 1024)
+	head := 0
+	q = append(q, src)
+	visited[src] = true
+
+	for head < len(q) {
+		u := q[head]
+		head++
+
+		for _, v := range adj[u] {
+			if !visited[v] {
+				visited[v] = true
+				parent[v] = u
+				if v == dst {
+					return reconstruct(parent, src, dst)
+				}
+				q = append(q, v)
+			}
+		}
+	}
+	return nil
+}
+
+func reconstruct(parent map[string]string, src, dst string) []string {
+	path := []string{dst}
+	cur := dst
+	for cur != src {
+		p, ok := parent[cur]
+		if !ok {
+			return nil // safety guard
+		}
+		cur = p
+		path = append(path, cur)
+	}
+	// reverse in-place
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	return path
+}
+


### PR DESCRIPTION
Address silent failure in ETL step. Rewired logging hooks to capture late-stage errors. Sanity tested with anonymized inputs